### PR TITLE
feat: Update discovery page ux

### DIFF
--- a/components/QuestionIP.tsx
+++ b/components/QuestionIP.tsx
@@ -149,7 +149,7 @@ const QuestionIP = ({
       <Card className="w-full backdrop-blur-lg bg-background/30 border border-white/10 shadow-xl overflow-hidden p-8">
         <div className="flex flex-col items-center justify-center py-8">
           <Loading />
-          <p className="text-white/70 mt-4">Loading discovery session...</p>
+          <p className="text-white/70 mt-4">Loading Agent Sessions...</p>
         </div>
       </Card>
     )
@@ -216,7 +216,7 @@ const QuestionIP = ({
           Session Complete
         </CardTitle>
         <CardDescription className="text-white/90 mt-2">
-          Thank you for using the Discovery Session
+          Thank you for using Agent Sessions
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -263,7 +263,7 @@ const QuestionIP = ({
             </div>
           )}
           <p className="text-white/70">
-            Explore your idea through interactive conversation
+            Agent-to-Agent and Agent-to-Human Conversations about your Idea
           </p>
         </div>
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -582,10 +582,10 @@ export default function ChatUI({
     >
       <CardHeader>
         <CardTitle className="text-2xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
-          Discovery Session
+          Agent Sessions
         </CardTitle>
         <CardDescription>
-          {doc.name} - {doc.description}
+          {doc.name}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">


### PR DESCRIPTION
## Changes

- Change 'Explore your idea...' to 'Agent-to-Agent and Agent-to-Human Conversations about your Idea'
- Rename 'Discovery Session' to 'Agent Sessions' in multiple locations
- Remove redundant description display in the chat component

This PR updates the terminology in the discovery page UI to better reflect the agent-to-agent interactions and improves the interface by removing redundant information.