### PR TITLE
Set pricing for protected eval

### DIFF
--- a/components/AddIP.tsx
+++ b/components/AddIP.tsx
@@ -34,7 +34,9 @@ const AppIP = () => {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [isTermsModalOpen, setIsTermsModalOpen] = useState(false)
   const [businessModel, setBusinessModel] = useState('Protected Evaluation')
-  const [evaluationPeriod, setEvaluationPeriod] = useState('one-day')
+  const [isDayEnabled, setIsDayEnabled] = useState(false)
+  const [isWeekEnabled, setIsWeekEnabled] = useState(false)
+  const [isMonthEnabled, setIsMonthEnabled] = useState(false)
   const [dayPrice, setDayPrice] = useState('0')
   const [weekPrice, setWeekPrice] = useState('0')
   const [monthPrice, setMonthPrice] = useState('0')
@@ -174,15 +176,19 @@ const AppIP = () => {
             downSampledUnifiedAccessControlConditions,
         },
         category: businessModel || 'Intellectual Property',
-        tags: ['IP', evaluationPeriod],
+        tags: ['IP', 'custom-pricing'],
         // Include all terms information
         terms: {
           businessModel,
-          evaluationPeriod,
+          enabledPeriods: {
+            day: isDayEnabled,
+            week: isWeekEnabled,
+            month: isMonthEnabled,
+          },
           pricing: {
-            dayPrice,
-            weekPrice,
-            monthPrice,
+            dayPrice: isDayEnabled ? dayPrice : '0',
+            weekPrice: isWeekEnabled ? weekPrice : '0',
+            monthPrice: isMonthEnabled ? monthPrice : '0',
           },
           ndaRequired: ndaConfirmed,
         },
@@ -216,7 +222,9 @@ const AppIP = () => {
     name,
     litClient,
     businessModel,
-    evaluationPeriod,
+    isDayEnabled,
+    isWeekEnabled,
+    isMonthEnabled,
     dayPrice,
     weekPrice,
     monthPrice,
@@ -529,20 +537,18 @@ const AppIP = () => {
                     <div className="space-y-3">
                       <div
                         className={`flex items-center space-x-2 p-3 border ${
-                          evaluationPeriod === 'one-day'
+                          isDayEnabled
                             ? 'border-primary/50'
                             : 'border-white/20'
                         } bg-muted/30 rounded-xl cursor-pointer hover:bg-muted/40 transition-colors`}
-                        onClick={() => setEvaluationPeriod('one-day')}
+                        onClick={() => setIsDayEnabled(!isDayEnabled)}
                       >
                         <input
-                          type="radio"
+                          type="checkbox"
                           id="one-day"
-                          name="evaluation-period"
-                          value="one-day"
-                          checked={evaluationPeriod === 'one-day'}
-                          onChange={() => setEvaluationPeriod('one-day')}
-                          className="text-primary rounded-full"
+                          checked={isDayEnabled}
+                          onChange={() => setIsDayEnabled(!isDayEnabled)}
+                          className="text-primary rounded"
                         />
                         <label
                           htmlFor="one-day"
@@ -554,11 +560,18 @@ const AppIP = () => {
                           <span className="text-white/70 mr-2">$</span>
                           <button
                             type="button"
-                            className="py-1 px-3 rounded bg-muted/40 border border-white/20 text-white"
+                            className={`py-1 px-3 rounded ${
+                              isDayEnabled 
+                                ? 'bg-muted/40 border border-white/20 text-white'
+                                : 'bg-muted/20 border border-white/10 text-white/50 cursor-not-allowed'
+                            }`}
                             onClick={(e) => {
                               e.stopPropagation();
-                              setIsDayPriceModalOpen(true);
+                              if (isDayEnabled) {
+                                setIsDayPriceModalOpen(true);
+                              }
                             }}
+                            disabled={!isDayEnabled}
                           >
                             {dayPrice}
                           </button>
@@ -567,20 +580,18 @@ const AppIP = () => {
 
                       <div
                         className={`flex items-center space-x-2 p-3 border ${
-                          evaluationPeriod === 'one-week'
+                          isWeekEnabled
                             ? 'border-primary/50'
                             : 'border-white/20'
                         } bg-muted/30 rounded-xl cursor-pointer hover:bg-muted/40 transition-colors`}
-                        onClick={() => setEvaluationPeriod('one-week')}
+                        onClick={() => setIsWeekEnabled(!isWeekEnabled)}
                       >
                         <input
-                          type="radio"
+                          type="checkbox"
                           id="one-week"
-                          name="evaluation-period"
-                          value="one-week"
-                          checked={evaluationPeriod === 'one-week'}
-                          onChange={() => setEvaluationPeriod('one-week')}
-                          className="text-primary rounded-full"
+                          checked={isWeekEnabled}
+                          onChange={() => setIsWeekEnabled(!isWeekEnabled)}
+                          className="text-primary rounded"
                         />
                         <label
                           htmlFor="one-week"
@@ -592,11 +603,18 @@ const AppIP = () => {
                           <span className="text-white/70 mr-2">$</span>
                           <button
                             type="button"
-                            className="py-1 px-3 rounded bg-muted/40 border border-white/20 text-white"
+                            className={`py-1 px-3 rounded ${
+                              isWeekEnabled 
+                                ? 'bg-muted/40 border border-white/20 text-white'
+                                : 'bg-muted/20 border border-white/10 text-white/50 cursor-not-allowed'
+                            }`}
                             onClick={(e) => {
                               e.stopPropagation();
-                              setIsWeekPriceModalOpen(true);
+                              if (isWeekEnabled) {
+                                setIsWeekPriceModalOpen(true);
+                              }
                             }}
+                            disabled={!isWeekEnabled}
                           >
                             {weekPrice}
                           </button>
@@ -605,20 +623,18 @@ const AppIP = () => {
 
                       <div
                         className={`flex items-center space-x-2 p-3 border ${
-                          evaluationPeriod === 'one-month'
+                          isMonthEnabled
                             ? 'border-primary/50'
                             : 'border-white/20'
                         } bg-muted/30 rounded-xl cursor-pointer hover:bg-muted/40 transition-colors`}
-                        onClick={() => setEvaluationPeriod('one-month')}
+                        onClick={() => setIsMonthEnabled(!isMonthEnabled)}
                       >
                         <input
-                          type="radio"
+                          type="checkbox"
                           id="one-month"
-                          name="evaluation-period"
-                          value="one-month"
-                          checked={evaluationPeriod === 'one-month'}
-                          onChange={() => setEvaluationPeriod('one-month')}
-                          className="text-primary rounded-full"
+                          checked={isMonthEnabled}
+                          onChange={() => setIsMonthEnabled(!isMonthEnabled)}
+                          className="text-primary rounded"
                         />
                         <label
                           htmlFor="one-month"
@@ -630,11 +646,18 @@ const AppIP = () => {
                           <span className="text-white/70 mr-2">$</span>
                           <button
                             type="button"
-                            className="py-1 px-3 rounded bg-muted/40 border border-white/20 text-white"
+                            className={`py-1 px-3 rounded ${
+                              isMonthEnabled 
+                                ? 'bg-muted/40 border border-white/20 text-white'
+                                : 'bg-muted/20 border border-white/10 text-white/50 cursor-not-allowed'
+                            }`}
                             onClick={(e) => {
                               e.stopPropagation();
-                              setIsMonthPriceModalOpen(true);
+                              if (isMonthEnabled) {
+                                setIsMonthPriceModalOpen(true);
+                              }
                             }}
+                            disabled={!isMonthEnabled}
                           >
                             {monthPrice}
                           </button>
@@ -682,6 +705,13 @@ const AppIP = () => {
                         alert('Please confirm you have a signed NDA in place')
                         return
                       }
+                      
+                      // Check if at least one duration is selected
+                      if (!isDayEnabled && !isWeekEnabled && !isMonthEnabled) {
+                        alert('Please select at least one evaluation period')
+                        return
+                      }
+                      
                       // Save terms logic would go here
                       setTermsAccepted(true)
                       setIsTermsModalOpen(false)

--- a/components/AddIP.tsx
+++ b/components/AddIP.tsx
@@ -35,11 +35,14 @@ const AppIP = () => {
   const [isTermsModalOpen, setIsTermsModalOpen] = useState(false)
   const [businessModel, setBusinessModel] = useState('Protected Evaluation')
   const [evaluationPeriod, setEvaluationPeriod] = useState('one-day')
-  const [dayPrice, setDayPrice] = useState('5.00')
-  const [weekPrice, setWeekPrice] = useState('25.00')
-  const [monthPrice, setMonthPrice] = useState('90.00')
+  const [dayPrice, setDayPrice] = useState('0')
+  const [weekPrice, setWeekPrice] = useState('0')
+  const [monthPrice, setMonthPrice] = useState('0')
   const [ndaConfirmed, setNdaConfirmed] = useState(false)
   const [termsAccepted, setTermsAccepted] = useState(false)
+  const [isDayPriceModalOpen, setIsDayPriceModalOpen] = useState(false)
+  const [isWeekPriceModalOpen, setIsWeekPriceModalOpen] = useState(false)
+  const [isMonthPriceModalOpen, setIsMonthPriceModalOpen] = useState(false)
   const stytchClient = useStytch()
   const [docId, setDocId] = useState('')
   const [status, setStatus] = useState<IPAudit>()
@@ -549,15 +552,16 @@ const AppIP = () => {
                         </label>
                         <div className="flex items-center">
                           <span className="text-white/70 mr-2">$</span>
-                          <input
-                            type="number"
-                            min="0"
-                            step="0.01"
-                            value={dayPrice}
-                            onChange={(e) => setDayPrice(e.target.value)}
-                            className="w-16 p-1 rounded bg-muted/40 border-white/20 text-white text-right"
-                            onClick={(e) => e.stopPropagation()}
-                          />
+                          <button
+                            type="button"
+                            className="py-1 px-3 rounded bg-muted/40 border border-white/20 text-white"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setIsDayPriceModalOpen(true);
+                            }}
+                          >
+                            {dayPrice}
+                          </button>
                         </div>
                       </div>
 
@@ -586,15 +590,16 @@ const AppIP = () => {
                         </label>
                         <div className="flex items-center">
                           <span className="text-white/70 mr-2">$</span>
-                          <input
-                            type="number"
-                            min="0"
-                            step="0.01"
-                            value={weekPrice}
-                            onChange={(e) => setWeekPrice(e.target.value)}
-                            className="w-16 p-1 rounded bg-muted/40 border-white/20 text-white text-right"
-                            onClick={(e) => e.stopPropagation()}
-                          />
+                          <button
+                            type="button"
+                            className="py-1 px-3 rounded bg-muted/40 border border-white/20 text-white"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setIsWeekPriceModalOpen(true);
+                            }}
+                          >
+                            {weekPrice}
+                          </button>
                         </div>
                       </div>
 
@@ -623,15 +628,16 @@ const AppIP = () => {
                         </label>
                         <div className="flex items-center">
                           <span className="text-white/70 mr-2">$</span>
-                          <input
-                            type="number"
-                            min="0"
-                            step="0.01"
-                            value={monthPrice}
-                            onChange={(e) => setMonthPrice(e.target.value)}
-                            className="w-16 p-1 rounded bg-muted/40 border-white/20 text-white text-right"
-                            onClick={(e) => e.stopPropagation()}
-                          />
+                          <button
+                            type="button"
+                            className="py-1 px-3 rounded bg-muted/40 border border-white/20 text-white"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setIsMonthPriceModalOpen(true);
+                            }}
+                          >
+                            {monthPrice}
+                          </button>
                         </div>
                       </div>
                     </div>
@@ -697,6 +703,168 @@ const AppIP = () => {
               accept=".txt,.md,.markdown,text/plain,text/markdown"
               className="hidden"
             />
+
+            {/* Day Price Modal */}
+            <Modal
+              isOpen={isDayPriceModalOpen}
+              onClose={() => setIsDayPriceModalOpen(false)}
+              title="Select Daily Price"
+            >
+              <div className="space-y-4">
+                <p className="text-white/90">
+                  Select a price for one day access:
+                </p>
+                <div className="grid grid-cols-3 gap-4 mt-4">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDayPrice('0');
+                      setIsDayPriceModalOpen(false);
+                    }}
+                    className="p-4 border border-white/20 bg-muted/30 rounded-xl hover:bg-muted/50 text-white text-center"
+                  >
+                    $0
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDayPrice('50');
+                      setIsDayPriceModalOpen(false);
+                    }}
+                    className="p-4 border border-white/20 bg-muted/30 rounded-xl hover:bg-muted/50 text-white text-center"
+                  >
+                    $50
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDayPrice('100');
+                      setIsDayPriceModalOpen(false);
+                    }}
+                    className="p-4 border border-white/20 bg-muted/30 rounded-xl hover:bg-muted/50 text-white text-center"
+                  >
+                    $100
+                  </button>
+                </div>
+                <div className="flex justify-end space-x-3 mt-6">
+                  <Button
+                    variant="ghost"
+                    onClick={() => setIsDayPriceModalOpen(false)}
+                    className="text-white/90 hover:bg-muted/50 rounded-xl h-11"
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            </Modal>
+
+            {/* Week Price Modal */}
+            <Modal
+              isOpen={isWeekPriceModalOpen}
+              onClose={() => setIsWeekPriceModalOpen(false)}
+              title="Select Weekly Price"
+            >
+              <div className="space-y-4">
+                <p className="text-white/90">
+                  Select a price for one week access:
+                </p>
+                <div className="grid grid-cols-3 gap-4 mt-4">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setWeekPrice('0');
+                      setIsWeekPriceModalOpen(false);
+                    }}
+                    className="p-4 border border-white/20 bg-muted/30 rounded-xl hover:bg-muted/50 text-white text-center"
+                  >
+                    $0
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setWeekPrice('50');
+                      setIsWeekPriceModalOpen(false);
+                    }}
+                    className="p-4 border border-white/20 bg-muted/30 rounded-xl hover:bg-muted/50 text-white text-center"
+                  >
+                    $50
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setWeekPrice('200');
+                      setIsWeekPriceModalOpen(false);
+                    }}
+                    className="p-4 border border-white/20 bg-muted/30 rounded-xl hover:bg-muted/50 text-white text-center"
+                  >
+                    $200
+                  </button>
+                </div>
+                <div className="flex justify-end space-x-3 mt-6">
+                  <Button
+                    variant="ghost"
+                    onClick={() => setIsWeekPriceModalOpen(false)}
+                    className="text-white/90 hover:bg-muted/50 rounded-xl h-11"
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            </Modal>
+
+            {/* Month Price Modal */}
+            <Modal
+              isOpen={isMonthPriceModalOpen}
+              onClose={() => setIsMonthPriceModalOpen(false)}
+              title="Select Monthly Price"
+            >
+              <div className="space-y-4">
+                <p className="text-white/90">
+                  Select a price for one month access:
+                </p>
+                <div className="grid grid-cols-3 gap-4 mt-4">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setMonthPrice('0');
+                      setIsMonthPriceModalOpen(false);
+                    }}
+                    className="p-4 border border-white/20 bg-muted/30 rounded-xl hover:bg-muted/50 text-white text-center"
+                  >
+                    $0
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setMonthPrice('200');
+                      setIsMonthPriceModalOpen(false);
+                    }}
+                    className="p-4 border border-white/20 bg-muted/30 rounded-xl hover:bg-muted/50 text-white text-center"
+                  >
+                    $200
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setMonthPrice('800');
+                      setIsMonthPriceModalOpen(false);
+                    }}
+                    className="p-4 border border-white/20 bg-muted/30 rounded-xl hover:bg-muted/50 text-white text-center"
+                  >
+                    $800
+                  </button>
+                </div>
+                <div className="flex justify-end space-x-3 mt-6">
+                  <Button
+                    variant="ghost"
+                    onClick={() => setIsMonthPriceModalOpen(false)}
+                    className="text-white/90 hover:bg-muted/50 rounded-xl h-11"
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            </Modal>
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- Added popup modals for each evaluation period duration to select pricing options
- For daily pricing, users can select $0, $50, or $100
- For weekly pricing, users can select $0, $50, or $200
- For monthly pricing, users can select $0, $200, or $800
- The selected price is displayed next to the duration option

## Test plan
- Test each pricing modal opens when clicking on the price button
- Verify price selection updates the displayed price
- Confirm price selections are preserved when submitting the form