### PR TITLE
Add Idea Shop mode for non-authenticated users

### DIFF
--- a/app/idea-shop/[id]/page.tsx
+++ b/app/idea-shop/[id]/page.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import Authenticated from '@/components/Authenticated'
+import DetailIP from '@/components/DetailIP'
+import { useParams } from 'next/navigation'
+
+export default function ShopDetail() {
+  const params = useParams()
+  const docId = params?.id as string
+
+  return (
+    <Authenticated ideaShopMode={true} requireLit={false} requireFirebase={false}>
+      <DetailIP docId={docId} shopMode={true} />
+    </Authenticated>
+  )
+}

--- a/app/idea-shop/page.tsx
+++ b/app/idea-shop/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import Authenticated from '@/components/Authenticated'
+import CardGrid from '@/components/card-grid'
+
+export default function IdeaShop() {
+  return (
+    <Authenticated ideaShopMode={true} requireFirebase={false} requireLit={false}>
+      <div className="w-full max-w-7xl mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold text-primary mb-6 text-center">
+          Idea Shop
+        </h1>
+        <p className="text-white/80 mb-8 text-center max-w-3xl mx-auto">
+          Browse our collection of intellectual property. Sign in to purchase access or add your own ideas to the marketplace.
+        </p>
+        <CardGrid shopMode={true} />
+      </div>
+    </Authenticated>
+  )
+}

--- a/components/NavigationHeader.tsx
+++ b/components/NavigationHeader.tsx
@@ -86,14 +86,25 @@ export default function NavigationHeader() {
           </Link>
         )}
         <Link
-          href="/list-ip"
+          href="/idea-shop"
           className="px-3 py-2 text-sm font-medium text-white hover:text-primary/90 cursor-pointer transition-colors"
           onClick={() =>
-            traceAction('Navigate', undefined, { destination: '/list-ip' })
+            traceAction('Navigate', undefined, { destination: '/idea-shop' })
           }
         >
-          Explore Ideas
+          Idea Shop
         </Link>
+        {isAuthenticated && (
+          <Link
+            href="/list-ip"
+            className="px-3 py-2 text-sm font-medium text-white hover:text-primary/90 cursor-pointer transition-colors"
+            onClick={() =>
+              traceAction('Navigate', undefined, { destination: '/list-ip' })
+            }
+          >
+            Explore Ideas
+          </Link>
+        )}
       </nav>
 
       {/* Account menu (hamburger) using DropdownMenu instead of MenubarMenu */}

--- a/components/card-grid.tsx
+++ b/components/card-grid.tsx
@@ -29,9 +29,10 @@ function getImageWidth() {
 type CardGridProps = {
   filter?: QueryCompositeFilterConstraint
   itemsPerPage?: number
+  shopMode?: boolean
 }
 
-function CardGrid({ filter, itemsPerPage = 16 }: CardGridProps) {
+function CardGrid({ filter, itemsPerPage = 16, shopMode = false }: CardGridProps) {
   const [imageWidth, setImageWidth] = useState(getImageWidth()) // Default width
   const [currentPage, setCurrentPage] = useState(1)
   const { data: visibleItems, pages: totalPages } = useIPs({
@@ -40,6 +41,7 @@ function CardGrid({ filter, itemsPerPage = 16 }: CardGridProps) {
     itemsPerPage,
     currentPage,
     filter,
+    shopMode,
   }) || { pages: 1 }
 
   // Responsive image size calculation

--- a/components/home-app.tsx
+++ b/components/home-app.tsx
@@ -78,7 +78,14 @@ function HomeApp() {
         {/* Button Section */}
         <div className="flex flex-col sm:flex-row gap-4 mt-10">
           {
-            !isInitialized ? null : isInitialized && user ? (
+            !isInitialized ? (
+              <Link
+                href="/idea-shop"
+                className="px-8 py-4 bg-secondary hover:bg-secondary/80 text-black font-medium rounded-xl transition-all shadow-lg hover:shadow-secondary/30 hover:scale-105 text-center"
+              >
+                Browse Idea Shop
+              </Link>
+            ) : isInitialized && user ? (
               <>
                 <Link
                   href="/add-ip"
@@ -99,7 +106,14 @@ function HomeApp() {
                   Explore Ideas
                 </Link>
               </>
-            ) : null /* Removed AuthButton from here */
+            ) : (
+              <Link
+                href="/idea-shop"
+                className="px-8 py-4 bg-secondary hover:bg-secondary/80 text-black font-medium rounded-xl transition-all shadow-lg hover:shadow-secondary/30 hover:scale-105 text-center"
+              >
+                Browse Idea Shop
+              </Link>
+            )
           }
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add public Idea Shop mode that allows browsing ideas without authentication
- Display basic idea information while restricting purchase and NDA actions
- Add Idea Shop navigation link for all users

## Test plan
1. Without logging in, navigate to the Idea Shop
2. Browse all ideas in the shop
3. Click on an idea to view details
4. Verify NDA requirements are shown but require login
5. Verify pricing is visible but purchase requires login
6. Test navigation between shop, detail pages, and home