### PR TITLE
feat: Add Cypress test manifest and logo test point

### DIFF
--- a/app/api/dev-tools/cypress-test-manifest/route.ts
+++ b/app/api/dev-tools/cypress-test-manifest/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+import fs from 'node:fs'
+import path from 'node:path'
+
+export async function GET() {
+  try {
+    const manifestPath = path.join(
+      process.cwd(),
+      'dev-tools',
+      'cypress-test-manifest.json'
+    )
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+    return NextResponse.json(manifest)
+  } catch (error) {
+    console.error('Error reading test manifest:', error)
+    return NextResponse.json(
+      { error: 'Failed to read test manifest' },
+      { status: 500 }
+    )
+  }
+}

--- a/components/NavigationHeader.tsx
+++ b/components/NavigationHeader.tsx
@@ -62,6 +62,7 @@ export default function NavigationHeader() {
       <Link
         href="/"
         className="mr-4"
+        data-testid="nav-logo"
         onClick={() => traceAction('Navigate', undefined, { destination: '/' })}
       >
         <Image

--- a/dev-tools/cypress-test-manifest.json
+++ b/dev-tools/cypress-test-manifest.json
@@ -1,0 +1,87 @@
+{
+  "appInfo": {
+    "name": "SafeIdea",
+    "version": "1.0.0",
+    "description": "Secure platform for sharing and selling intellectual property and ideas"
+  },
+  "testPoints": {
+    "navigation": {
+      "selector": ".flex.w-full.items-center.justify-between",
+      "elements": [
+        {
+          "id": "logo",
+          "selector": "[data-testid='nav-logo']",
+          "type": "link",
+          "description": "Main navigation logo that returns to home page"
+        }
+      ],
+      "actions": ["navigation"]
+    },
+    "addIdeaForm": {
+      "selector": ".add-idea-form",
+      "elements": [
+        {
+          "id": "titleInput",
+          "selector": "[data-testid='idea-title-input']",
+          "type": "input",
+          "description": "Idea title input field"
+        },
+        {
+          "id": "descriptionInput",
+          "selector": "[data-testid='idea-description-input']",
+          "type": "textarea",
+          "description": "Idea description textarea"
+        },
+        {
+          "id": "addEncryptButton",
+          "selector": "[data-testid='add-encrypt-button']",
+          "type": "button",
+          "description": "Add and encrypt idea button"
+        },
+        {
+          "id": "fileUploadInput",
+          "selector": "[data-testid='file-upload-input']",
+          "type": "input",
+          "description": "Hidden file input for uploads"
+        },
+        {
+          "id": "fileUploadZone",
+          "selector": "[data-testid='file-upload-zone']",
+          "type": "div",
+          "description": "File upload completion indicator"
+        },
+        {
+          "id": "setTermsButton",
+          "selector": "[data-testid='set-terms-button']",
+          "type": "button",
+          "description": "Set terms button"
+        },
+        {
+          "id": "createIdeaButton",
+          "selector": "[data-testid='create-idea-button']",
+          "type": "button",
+          "description": "Create idea button"
+        }
+      ],
+      "actions": ["addIdea", "uploadFile", "setTerms", "createIdea"]
+    },
+    "termsDialog": {
+      "selector": "[data-testid='terms-dialog']",
+      "elements": [
+        {
+          "id": "businessModelSelect",
+          "selector": "[data-testid='business-model-select']",
+          "type": "select",
+          "description": "Business model select dropdown"
+        },
+        {
+          "id": "termsAcceptButton",
+          "selector": "[data-testid='terms-accept-button']",
+          "type": "button",
+          "description": "Accept terms button"
+        }
+      ],
+      "actions": ["selectBusinessModel", "acceptTerms"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add support for external Cypress testing by creating a standardized test manifest
- Add data-testid attribute to the navigation logo for Cypress testing
- Create API endpoint to serve the test manifest