### PR TITLE
feat: Add HTML-based Cypress test manifest

### DIFF
--- a/components/NavigationHeader.tsx
+++ b/components/NavigationHeader.tsx
@@ -62,6 +62,7 @@ export default function NavigationHeader() {
       <Link
         href="/"
         className="mr-4"
+        data-testid="nav-logo"
         onClick={() => traceAction('Navigate', undefined, { destination: '/' })}
       >
         <Image

--- a/public/cypress-test.html
+++ b/public/cypress-test.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>SafeIdea Cypress Test Points</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      line-height: 1.6;
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 20px;
+      color: #333;
+    }
+    h1 {
+      color: #1F7BBC;
+      border-bottom: 2px solid #eee;
+      padding-bottom: 10px;
+    }
+    code {
+      background-color: #f5f5f5;
+      padding: 2px 5px;
+      border-radius: 3px;
+      font-family: Consolas, Monaco, 'Andale Mono', monospace;
+    }
+    .note {
+      background-color: #f8f9fa;
+      border-left: 4px solid #1F7BBC;
+      padding: 15px;
+      margin: 20px 0;
+    }
+  </style>
+</head>
+<body>
+  <h1>SafeIdea Cypress Test Points</h1>
+  
+  <p>This page contains test points for Cypress automation in a machine-readable format.</p>
+  
+  <div class="note">
+    <p><strong>Note:</strong> This page is not meant for human consumption. It provides structured data for Cypress tests.</p>
+  </div>
+
+  <script type="application/json" id="cypress-manifest">
+  {
+    "appInfo": {
+      "name": "SafeIdea",
+      "version": "1.0.0",
+      "description": "Secure platform for sharing and selling intellectual property and ideas"
+    },
+    "testPoints": {
+      "navigation": {
+        "selector": ".flex.w-full.items-center.justify-between",
+        "elements": [
+          {
+            "id": "logo",
+            "selector": "[data-testid='nav-logo']",
+            "type": "link",
+            "description": "Main navigation logo that returns to home page"
+          }
+        ],
+        "actions": ["navigation"]
+      },
+      "addIdeaForm": {
+        "selector": ".add-idea-form",
+        "elements": [
+          {
+            "id": "titleInput",
+            "selector": "input[placeholder='Idea Title']",
+            "type": "input",
+            "description": "Idea title input field"
+          },
+          {
+            "id": "descriptionInput",
+            "selector": "textarea[placeholder='Describe your idea...']",
+            "type": "textarea",
+            "description": "Idea description textarea"
+          },
+          {
+            "id": "fileUploadZone",
+            "selector": ".file-upload-zone",
+            "type": "div",
+            "description": "File upload zone"
+          },
+          {
+            "id": "createIdeaButton",
+            "selector": "button:contains('Create Idea')",
+            "type": "button",
+            "description": "Create idea button"
+          }
+        ],
+        "actions": ["addIdea", "uploadFile", "createIdea"]
+      },
+      "ideaList": {
+        "selector": ".grid.grid-cols-1.sm\\:grid-cols-2.lg\\:grid-cols-4",
+        "elements": [
+          {
+            "id": "ideaCard",
+            "selector": ".shadow-xl.hover\\:shadow-primary\\/20",
+            "type": "div",
+            "description": "Individual idea card"
+          },
+          {
+            "id": "viewDetailsButton",
+            "selector": "a:contains('View Details')",
+            "type": "link",
+            "description": "Button to view idea details"
+          }
+        ],
+        "actions": ["viewIdea"]
+      },
+      "authentication": {
+        "elements": [
+          {
+            "id": "signInButton",
+            "selector": "button:contains('Sign In')",
+            "type": "button",
+            "description": "Sign in button"
+          },
+          {
+            "id": "accountMenu",
+            "selector": "button.h-10.w-10.rounded-full",
+            "type": "button",
+            "description": "Account menu button (hamburger)"
+          }
+        ],
+        "actions": ["login", "logout"]
+      }
+    }
+  }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a new HTML-based approach for Cypress test points:

- Creates a single  file in the public directory
- Embeds the test point manifest as a JSON object within a script tag
- Requires no server-side processing unlike the previous JSON endpoint approach
- Includes test points for navigation, forms, and key UI elements
- Formatted to be both machine-readable for tests and human-readable for developers

This approach simplifies the test discovery process compared to the previous approach, making it more maintainable and reducing the server-side implementation complexity.

This builds on top of PR #111 (Remove Cypress automation infrastructure) by replacing the removed functionality with a more modern and efficient HTML-based approach.
