### PR TITLE
fix: Move logo from top center to bottom right of welcome card

### DIFF
--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -8,11 +8,13 @@ interface LogoProps {
 
 export const Logo: FC<LogoProps> = ({ showText = true }) => {
   return (
-    <div className="flex flex-col items-center justify-center w-full max-w-md mx-auto mb-10">
+    <div
+      className={`flex flex-col items-center justify-center ${showText ? 'w-full max-w-md mx-auto mb-10' : 'w-auto'}`}
+    >
       {/* Logo Image */}
       <Image
-        width={192}
-        height={192}
+        width={showText ? 192 : 120}
+        height={showText ? 192 : 120}
         className="rounded-full shadow-lg border-2 border-primary/30"
         priority
         src="/svg/Black+Yellow.svg"

--- a/components/home-app.tsx
+++ b/components/home-app.tsx
@@ -18,11 +18,9 @@ function LoggedInHome() {
   return (
     <>
       <div className="flex flex-col items-center justify-center min-h-screen px-6 py-16">
-        <Logo />
-
         {/* Description Section */}
-        <Card className="max-w-3xl mx-auto text-center backdrop-blur-lg bg-background/30 border-border mt-8">
-          <CardHeader>
+        <Card className="max-w-3xl mx-auto text-center backdrop-blur-lg bg-background/30 border-border">
+          <CardHeader className="relative">
             <CardTitle className="text-2xl text-foreground">
               Welcome to{' '}
               <span className="text-primary font-semibold">SafeIdea.net</span>
@@ -30,8 +28,11 @@ function LoggedInHome() {
             <CardDescription className="text-lg text-foreground/90">
               The alpha version of our IP protection platform
             </CardDescription>
+            <div className="absolute -bottom-24 right-6">
+              <Logo showText={false} />
+            </div>
           </CardHeader>
-          <CardContent>
+          <CardContent className="mt-8">
             <p className="text-lg leading-relaxed text-foreground/90">
               SafeIdea is a new decentralized service designed to help creators
               and inventors securely store, share and benefit from their digital


### PR DESCRIPTION
Move the logo from the top-center position to the bottom-right of the welcome card on the logged-in home page. Make the logo size responsive based on context.