### PR TITLE
Show early version welcome page to all users

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,8 @@
 'use client'
 
-import { useStytchUser } from '@stytch/nextjs'
 import HomeApp from '@/components/home-app'
-import SubscriptionHome from '@/app/subscription/home/page'
 
 export default function Home() {
-  const { user, isInitialized } = useStytchUser()
-
-  // If not authenticated, show subscription home page
-  if (isInitialized && !user) {
-    return <SubscriptionHome />
-  }
-
-  // If authenticated or still initializing, show the regular home app
+  // Always show the HomeApp (early version welcome page) for everyone
   return <HomeApp />
 }

--- a/components/home-app.tsx
+++ b/components/home-app.tsx
@@ -11,15 +11,18 @@ import {
   CardTitle,
   CardDescription,
 } from '@/components/ui/card'
-import WelcomeHome from './welcome-home'
 import { SubscriptionBanner } from './SubscriptionBanner'
 import { useVocabulary } from '@/lib/vocabulary'
 import { useFeature } from '@/hooks/useFeature'
 
-// Logged in version of the home page
+// Logged in version of the home page (now shown to everyone)
 function LoggedInHome() {
+  const { user, isInitialized } = useStytchUser()
   const { getTerm } = useVocabulary()
   const isAISite = useFeature('ai')
+
+  // Check if user is authenticated
+  const isAuthenticated = isInitialized && user
 
   // Determine if we're on AI site
   const isOnAISite =
@@ -84,20 +87,42 @@ function LoggedInHome() {
 
         {/* Button Section */}
         <div className="flex flex-col sm:flex-row gap-4 mt-10">
-          <Link
-            href={addIdeaRoute}
-            className="px-8 py-4 bg-primary hover:bg-primary/80 text-black font-medium rounded-xl transition-all shadow-lg hover:shadow-primary/30 hover:scale-105 text-center"
-            data-testid="home-add-idea-button"
-          >
-            {getTerm('item.add')}
-          </Link>
-          <Link
-            href="/list-ip/mine"
-            className="px-8 py-4 bg-accent hover:bg-accent/80 text-black font-medium rounded-xl transition-all shadow-lg hover:shadow-accent/30 hover:scale-105 text-center"
-            data-testid="home-my-ideas-button"
-          >
-            {getTerm('item.my')}
-          </Link>
+          {isAuthenticated ? (
+            <Link
+              href={addIdeaRoute}
+              className="px-8 py-4 bg-primary hover:bg-primary/80 text-black font-medium rounded-xl transition-all shadow-lg hover:shadow-primary/30 hover:scale-105 text-center"
+              data-testid="home-add-idea-button"
+            >
+              {getTerm('item.add')}
+            </Link>
+          ) : (
+            <button
+              type="button"
+              disabled
+              className="px-8 py-4 bg-primary/50 text-black/50 font-medium rounded-xl shadow-lg cursor-not-allowed text-center"
+              data-testid="home-add-idea-button"
+            >
+              {getTerm('item.add')} (Sign In Required)
+            </button>
+          )}
+          {isAuthenticated ? (
+            <Link
+              href="/list-ip/mine"
+              className="px-8 py-4 bg-accent hover:bg-accent/80 text-black font-medium rounded-xl transition-all shadow-lg hover:shadow-accent/30 hover:scale-105 text-center"
+              data-testid="home-my-ideas-button"
+            >
+              {getTerm('item.my')}
+            </Link>
+          ) : (
+            <button
+              type="button"
+              disabled
+              className="px-8 py-4 bg-accent/50 text-black/50 font-medium rounded-xl shadow-lg cursor-not-allowed text-center"
+              data-testid="home-my-ideas-button"
+            >
+              {getTerm('item.my')} (Sign In Required)
+            </button>
+          )}
           <Link
             href="/list-ip"
             className="px-8 py-4 bg-secondary hover:bg-secondary/80 text-black font-medium rounded-xl transition-all shadow-lg hover:shadow-secondary/30 hover:scale-105 text-center"
@@ -111,21 +136,10 @@ function LoggedInHome() {
   )
 }
 
-// This is the main component that decides which version to show
+// This is the main component that always shows the early version welcome page
 function HomeApp() {
-  const { user, isInitialized } = useStytchUser()
-
-  // If not initialized, show nothing
-  if (!isInitialized) {
-    return null
-  }
-
-  // Show the appropriate version based on login status
-  if (user) {
-    return <LoggedInHome />
-  }
-
-  return <WelcomeHome />
+  // Always show LoggedInHome (early version) for everyone
+  return <LoggedInHome />
 }
 
 function RootHomeApp() {


### PR DESCRIPTION
## Summary
- Display the testing mode welcome message to all visitors (both authenticated and non-authenticated)
- Show disabled buttons with "Sign In Required" text for non-authenticated users
- Keep the simple single-page add-ip flow instead of the 3-page version

## Changes
- Modified `app/page.tsx` to always show HomeApp component
- Updated `components/home-app.tsx` to:
  - Check authentication status and disable buttons accordingly
  - Show "(Sign In Required)" text on disabled buttons
  - Route to `/add-ip` (single-page flow) not `/add-ip/protect` (3-page flow)

## Result
- All users see the welcome message about the platform being in testing mode
- Non-authenticated users see disabled "Add Idea" and "My Ideas" buttons
- "Explore Ideas" button remains active for all users
- No marketing content is displayed

This creates a simplified evaluation experience that shows the early version of the app to everyone while maintaining proper access control.

🤖 Generated with [Claude Code](https://claude.ai/code)