### PR TITLE
Fix pricing persistence for multiple durations in SortedProducts

### DIFF
--- a/components/AddIP/SortedProducts.tsx
+++ b/components/AddIP/SortedProducts.tsx
@@ -40,7 +40,7 @@ export const SortedProducts = memo(
         <div key={product.id} className="flex flex-col">
           <div className="flex items-center space-x-2 p-3 border bg-muted/30 rounded-xl cursor-pointer hover:bg-muted/40 transition-colors">
             <Select
-              value={value?.[index]?.id || defaultPrices[0].id}
+              value={value?.[index]?.id || defaultPrices[index].id}
               onValueChange={(_priceValue: string) => {
                 const priceValue = _priceValue === '__none__' ? '' : _priceValue
                 const newPrice = sortedPrices.find(


### PR DESCRIPTION
## Summary
- Fixes an issue in the `SortedProducts` component where the default price selection did not correctly handle multiple durations
- Ensures the default price corresponds to the correct index rather than always using the first price

## Changes

### Components
- **SortedProducts.tsx**: Updated the `Select` component's `value` prop to use `defaultPrices[index].id` instead of `defaultPrices[0].id` to correctly persist pricing selections for multiple durations

## Test plan
- [x] Verify that the default price selection matches the correct duration index
- [x] Test changing price selections and ensure persistence across multiple durations
- [x] Confirm no regressions in UI behavior for product price selection

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/53b4bd3a-819d-4f17-acd9-990352a25f89